### PR TITLE
[1.x] FIX: Add CacheContract to Closure definition

### DIFF
--- a/src/Condition.php
+++ b/src/Condition.php
@@ -53,7 +53,7 @@ class Condition
      *
      * Ensure your 'condition' array contains a 'store', 'key' and 'hits' keys.
      *
-     * @return \Closure(array):bool
+     * @return \Closure(array, CacheContract):bool
      */
     public static function countCondition(): Closure
     {

--- a/src/Condition.php
+++ b/src/Condition.php
@@ -53,7 +53,7 @@ class Condition
      *
      * Ensure your 'condition' array contains a 'store', 'key' and 'hits' keys.
      *
-     * @return \Closure(array, CacheContract):bool
+     * @return \Closure(array<int, midex>, \Illuminate\Contracts\Cache\Factory):bool
      */
     public static function countCondition(): Closure
     {


### PR DESCRIPTION
This adds the CacheContract to docblock definition for the Closure returned from countCondition since it is required.