### PR TITLE
Typo: 'PRELOAD_ENABLE', not 'PRELOAD_ENABLED'

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,14 +104,14 @@ return [
 
 ```php
 return [
-    'enable' => env('PRELOAD_ENABLED'),
+    'enable' => env('PRELOAD_ENABLE'),
 ];
 ```
 
 By default, a global middleware is registered automatically on production environments. You can forcefully enable or disable this middleware using an environment variable set to `true` or `false`, respectively.
 
 ```dotenv
-PRELOAD_ENABLED=true
+PRELOAD_ENABLE=true
 ```
 
 #### Condition


### PR DESCRIPTION
The variable in **config/preload.php** is 'PRELOAD_ENABLE', not 'PRELOAD_ENABLE_D_' as stated in docs:
config/preload.php:18
'enabled' => env('PRELOAD_ENABLE'),

<!--

Thanks for contributing to this package! We only accept PR to the latest stable version.

If you're pushing a Feature:
- Title it: "[X.x] This new feature"
- Describe what the new feature enables
- Show a small code snippet of the new feature
- Ensure it doesn't break any feature.

If you're pushing a Fix:
- Title it: "[X.x] FIX: The bug name"
- Describe how it fixes in a few words.
- Ensure it doesn't break any feature.

All Pull Requests run with extensive tests for stable and latest versions of PHP and Laravel. 
Ensure your tests pass or your PR may be taken down.

If you're a Patreon supporter, this PR will have priority.
Not a Patreon supporter? Become one at https://patreon.com/packagesforlaravel
-->

# Description

This feature/fix allows to...

# Code samples

```php
Laragear::sample();
```

<!-- You may delete this section if it's a FIX -->
