### PR TITLE
[1.x] FIX: Request count in cache is not initialized. 

### DIFF
--- a/src/Condition.php
+++ b/src/Condition.php
@@ -61,6 +61,10 @@ class Condition
             // Increment the count by one. If it doesn't exist, we will start with 1.
             $count = $cache->store($options['store'])->increment($options['key']);
 
+            if (empty($count)) {
+                $cache->store($options['store'])->set($options['key'], 1);
+            }
+
             // If the count is not equal to the number of hits, bail out.
             if ($count !== $options['hits']) {
                 return false;


### PR DESCRIPTION
# Description

This fix initializes the request count in the cache in order to actually increment it in every request, and finally generate the preload.php used by opcache.